### PR TITLE
Causes all files to be downloaded, not just the last one

### DIFF
--- a/UpdaterLibrary/Services/PatchService.cs
+++ b/UpdaterLibrary/Services/PatchService.cs
@@ -231,7 +231,8 @@ namespace UpdaterLibrary.Services
                     _ = Directory.CreateDirectory(directory);
                 }
 
-                WebClient.DownloadFile(url, path);
+                WebClient client = new WebClient();
+                client.DownloadFileAsync(new Uri(url), path);
             }
             catch
             {


### PR DESCRIPTION
Using the same instance of WebClient causes only the last file to be downloaded.