### PR TITLE
Prevents freezing while downloading

### DIFF
--- a/PkodevUpdater/forms/UpdaterWindow.xaml.cs
+++ b/PkodevUpdater/forms/UpdaterWindow.xaml.cs
@@ -126,10 +126,10 @@ namespace PkodevUpdater.Forms
                     {
                         case "modified":
                         case "added":
-                            _backgroundQueueService.QueueTask(() => DownloadFile(commit)).Wait();
+                            await Task.Run(() => DownloadFile(commit));
                             break;
                         case "removed":
-                            _backgroundQueueService.QueueTask(() => DeleteFile(commit.Name)).Wait();
+                            await Task.Run(() => DeleteFile(commit.Name));
                             break;
                     }
                 }


### PR DESCRIPTION
This prevents the launcher from freezing while downloading. In my tests it worked fine, but it's best to check it out as this completely ignores your background queue service.